### PR TITLE
Fix android crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,8 @@ class SortableFlatList extends Component {
       })
     }
     // Spacer index differs according to placement. See note in onPanResponderRelease
-    return spacerIndex > activeRow ? spacerIndex + 1 : spacerIndex
+    const newSpacerIndex = spacerIndex > activeRow ? spacerIndex + 1 : spacerIndex
+    return Math.min(newSpacerIndex, this.props.data.length)
   }
 
   measureItem = (index) => {

--- a/index.js
+++ b/index.js
@@ -72,8 +72,7 @@ class SortableFlatList extends Component {
 
           this._androidStatusBarOffset = (isTranslucent || isHidden) ? StatusBar.currentHeight : 0
         }
-        const containerOffset = this._containerOffset === undefined ? 0 : this._containerOffset
-        this._offset.setValue((this._additionalOffset + containerOffset - this._androidStatusBarOffset - externalScrollOffset) * -1)
+        this._offset.setValue((this._additionalOffset + this._containerOffset - this._androidStatusBarOffset - externalScrollOffset) * -1)
         return false
       },
       onMoveShouldSetPanResponder: (evt, gestureState) => {
@@ -331,6 +330,7 @@ class SortableFlatList extends Component {
     const { horizontal, keyExtractor } = this.props
     return (
       <View
+        collapsable={false}
         ref={this.measureContainer}
         {...this._panResponder.panHandlers}
         style={styles.wrapper} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const initialState = {
   activeRow: -1,
   showHoverComponent: false,
   spacerIndex: -1,
-  scroll: false,
+  // scroll: false,
   hoverComponent: null,
   extraData: null,
 }
@@ -49,16 +49,16 @@ class SortableFlatList extends Component {
       onStartShouldSetPanResponderCapture: (evt, gestureState) => {
         const { pageX, pageY } = evt.nativeEvent
         const { externalScrollOffset, horizontal } = this.props
-        const tappedPixel = (horizontal ? pageX : pageY) + externalScrollOffset
+        const tappedPixel = horizontal ? pageX : pageY
 
-        const tappedRow = this._pixels[Math.floor(this._scrollOffset + tappedPixel)]
+        const tappedRow = this._pixels[Math.floor(this._scrollOffset + tappedPixel + externalScrollOffset)]
         if (tappedRow === undefined) return false
-        this._additionalOffset = (tappedPixel + this._scrollOffset) - this._measurements[tappedRow][horizontal ? 'x' : 'y']
+        this._additionalOffset = (tappedPixel + this._scrollOffset + externalScrollOffset) - this._measurements[tappedRow][horizontal ? 'x' : 'y']
         if (this._releaseAnim) {
           return false
         }
         this._moveAnim.setValue(tappedPixel)
-        this._move = tappedPixel
+        this._move = tappedPixel + externalScrollOffset
 
         // compensate for translucent or hidden StatusBar on android
         if (Platform.OS === 'android' && !horizontal) {
@@ -72,7 +72,8 @@ class SortableFlatList extends Component {
 
           this._androidStatusBarOffset = (isTranslucent || isHidden) ? StatusBar.currentHeight : 0
         }
-        this._offset.setValue((this._additionalOffset + this._containerOffset - this._androidStatusBarOffset - externalScrollOffset) * -1)
+        const containerOffset = this._containerOffset === undefined ? 0 : this._containerOffset
+        this._offset.setValue((this._additionalOffset + containerOffset - this._androidStatusBarOffset - externalScrollOffset) * -1)
         return false
       },
       onMoveShouldSetPanResponder: (evt, gestureState) => {
@@ -118,9 +119,9 @@ class SortableFlatList extends Component {
         const { x, y, width, height } = spacerElement
         const size = horizontal ? width : height
         const offset = horizontal ? x : y
-        const pos = offset - this._scrollOffset + this._additionalOffset + (isLastElement ? size : 0)
+        const pos = offset - this._scrollOffset + this._additionalOffset + (isLastElement ? size : 0) - externalScrollOffset
         const activeItemSize = horizontal ? activeMeasurements.width : activeMeasurements.height
-        this._releaseVal = pos - (isAfterActive ? activeItemSize : 0) - externalScrollOffset
+        this._releaseVal = pos - (isAfterActive ? activeItemSize : 0)
         if (this._releaseAnim) this._releaseAnim.stop()
         this._releaseAnim = Animated.spring(this._moveAnim, {
           toValue: this._releaseVal,
@@ -183,15 +184,15 @@ class SortableFlatList extends Component {
     requestAnimationFrame(this.animate)
   }
 
-  scroll = (scrollAmt, spacerIndex) => {
-    if (spacerIndex >= this.props.data.length) return this._flatList.scrollToEnd()
-    if (spacerIndex === -1) return
-    const currentScrollOffset = this._scrollOffset
-    const newOffset = currentScrollOffset + scrollAmt
-    const offset = Math.max(0, newOffset)
-    this._flatList.scrollToOffset({ offset, animated: false })
-  }
-
+  // scroll = (scrollAmt, spacerIndex) => {
+  //   const { externalScrollOffset } = this.props
+  //   if (spacerIndex >= this.props.data.length) return this._flatList.scrollToEnd()
+  //   if (spacerIndex === -1) return
+  //   const currentScrollOffset = this._scrollOffset + externalScrollOffset
+  //   const newOffset = currentScrollOffset + scrollAmt
+  //   const offset = Math.max(0, newOffset)
+  //   this._flatList.scrollToOffset({ offset, animated: false })
+  // }
 
   getSpacerIndex = (move, activeRow) => {
     const { horizontal } = this.props
@@ -259,7 +260,7 @@ class SortableFlatList extends Component {
   }
 
   moveEnd = () => {
-    if (!this._hasMoved) this.setState(initialState)
+    if (!this._hasMoved) this.setState(initialState, this.onReleaseAnimationEnd)
   }
 
   setRef = index => (ref) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-draggable-flatlist",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A drag-and-drop-enabled FlatList component for React Native",
   "types": "./index.d.ts",
   "main": "index.js",


### PR DESCRIPTION
This fixes a few things.  

- It cleans up some of the pixel calculations from the last PR that I had for a cleaner scroll.  
- It fixes a bug where it'll lock the scroll if you click and release without dragging.
- I commented out the `scroll` method because it didn't seem to be used anywhere.
- It fixes the android bug of crashing on click
- It fixes this bug where if you remove an item and then drag an item past the bottom, there's this weird snap.

Android is still weird where items will disappear sometimes.  I'm not sure what's going on here, but I think this has been a problem for a while.  It's driving me nuts, so maybe I can handle that in a separate PR and just deliver this for now.  If that's ok with you.